### PR TITLE
Fixed missing project.scripts in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dependencies = [
   "dbus-next>=0.2.3",
 ]
 
+[project.scripts]
+tado-local = "tado_local.__main__:main"
+
 [project.urls]
 Homepage = "https://github.com/AmpScm/tado-local"
 Repository = "https://github.com/AmpScm/tado-local.git"


### PR DESCRIPTION
My install broke after updating from https://github.com/AmpScm/TadoLocal/commit/f73045833e4844c5e429939a478a9c58789ffaba to the current revision. 

Also tried running `pip install -e .` again, but still got the following error:

```
Traceback (most recent call last):
  File "/opt/TadoLocal/venv/bin/tado-local", line 33, in <module>
    sys.exit(load_entry_point('tado-local', 'console_scripts', 'tado-local')()) 
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
  File "/opt/TadoLocal/venv/bin/tado-local", line 25, in importlib_load_entry_point 
    return next(matches).load() 
           ^^^^^^^^^^^^^ 
StopIteration
```

After a complete reinstall there was no `/opt/TadoLocal/venv/bin/tado-local` anymore 😢 

Seems this was because there was no `[project.scripts]` in pyproject.toml. This PR should fix that. ✅ 

There seem to be more undocumented changes since #f730458, such `hum_perc` in /zones being a `str` instead of an `int`, but these are not changed in this commit.