### PR TITLE
Migrate Home Assistant app build to Docker BuildKit

### DIFF
--- a/home-assistant/Dockerfile
+++ b/home-assistant/Dockerfile
@@ -1,5 +1,4 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:latest
 
 RUN apk add git py3-pip
 WORKDIR /usr/src/app


### PR DESCRIPTION
Replaced `BUILD_FROM` statements with architecture-agnostic `FROM` statement as per HA developer blog https://developers.home-assistant.io/blog/2026/04/02/builder-migration/

@AlexHunterCodes thanks for fixing this issue!
